### PR TITLE
patch driver station flash during astop/estop when match is in progress

### DIFF
--- a/model/event_settings.go
+++ b/model/event_settings.go
@@ -39,58 +39,59 @@ var (
 )
 
 type EventSettings struct {
-	Id                          int `db:"id"`
-	Name                        string
-	LogoSuffix                  string
-	PlayoffType                 PlayoffType
-	NumPlayoffAlliances         int
-	SelectionRound2Order        string
-	SelectionRound3Order        string
-	SelectionShowUnpickedTeams  bool
-	TbaDownloadEnabled          bool
-	TbaPublishingEnabled        bool
-	TbaEventCode                string
-	TbaSecretId                 string
-	TbaSecret                   string
-	NexusEnabled                bool
-	NetworkSecurityEnabled      bool
-	ApAddress                   string
-	ApPassword                  string
-	ApChannel                   int
-	SwitchAddress               string
-	SwitchPassword              string
-	SCCManagementEnabled        bool
-	RedSCCAddress               string
-	BlueSCCAddress              string
-	SCCUsername                 string
-	SCCPassword                 string
-	SCCUpCommands               string
-	SCCDownCommands             string
-	PlcAddress                  string
-	AlternateIOEnabled          bool
-	ScoreTableEstopAddress  		string
+	Id                              int `db:"id"`
+	Name                            string
+	LogoSuffix                      string
+	PlayoffType                     PlayoffType
+	NumPlayoffAlliances             int
+	SelectionRound2Order            string
+	SelectionRound3Order            string
+	SelectionShowUnpickedTeams      bool
+	TbaDownloadEnabled              bool
+	TbaPublishingEnabled            bool
+	TbaEventCode                    string
+	TbaSecretId                     string
+	TbaSecret                       string
+	NexusEnabled                    bool
+	NetworkSecurityEnabled          bool
+	ApAddress                       string
+	ApPassword                      string
+	ApChannel                       int
+	SwitchAddress                   string
+	SwitchPassword                  string
+	SCCManagementEnabled            bool
+	RedSCCAddress                   string
+	BlueSCCAddress                  string
+	SCCUsername                     string
+	SCCPassword                     string
+	SCCUpCommands                   string
+	SCCDownCommands                 string
+	PlcAddress                      string
+	AlternateIOEnabled              bool
+	ScoreTableEstopAddress          string
 	RedAllianceStationEstopAddress  string
 	BlueAllianceStationEstopAddress string
-	AdminPassword               string
-	TeamSignRed1Id              int
-	TeamSignRed2Id              int
-	TeamSignRed3Id              int
-	TeamSignRedTimerId          int
-	TeamSignBlue1Id             int
-	TeamSignBlue2Id             int
-	TeamSignBlue3Id             int
-	TeamSignBlueTimerId         int
-	UseLiteUdpPort              bool
-	BlackmagicAddresses         string
-	WarmupDurationSec           int
-	AutoDurationSec             int
-	PauseDurationSec            int
-	TeleopDurationSec           int
-	WarningRemainingDurationSec int
-	AutoBonusCoralThreshold     int
-	CoralBonusPerLevelThreshold int
-	CoralBonusCoopEnabled       bool
-	BargeBonusPointThreshold    int
+	AdminPassword                   string
+	TeamSignRed1Id                  int
+	TeamSignRed2Id                  int
+	TeamSignRed3Id                  int
+	TeamSignRedTimerId              int
+	TeamSignBlue1Id                 int
+	TeamSignBlue2Id                 int
+	TeamSignBlue3Id                 int
+	TeamSignBlueTimerId             int
+	UseLiteUdpPort                  bool
+	BlackmagicAddresses             string
+	WarmupDurationSec               int
+	AutoDurationSec                 int
+	PauseDurationSec                int
+	TeleopDurationSec               int
+	WarningRemainingDurationSec     int
+	AutoBonusCoralThreshold         int
+	CoralBonusPerLevelThreshold     int
+	CoralBonusCoopEnabled           bool
+	BargeBonusPointThreshold        int
+	FlashDSEnabled                  bool
 }
 
 func (database *Database) GetEventSettings() (*EventSettings, error) {

--- a/static/js/alliance_station_display_noflash.js
+++ b/static/js/alliance_station_display_noflash.js
@@ -96,23 +96,6 @@ var handleArenaStatus = function (data) {
       $("#match").attr("data-status", "");
     }
   }
-
-  if (!blink && blinkInterval) {
-    clearInterval(blinkInterval);
-    blinkInterval = null;
-  }
-
-
-  // Flash driver station display when A-Stopped or solid orange when E-Stopped
-  // Make sure match is not in progress to prevent flashing during match
-  $("#match").removeClass("solid-orange blink-orange");
-  if (stationStatus.EStop && data.MatchState==0) {
-    $("#match").addClass("solid-orange"); // E-stop: solid orange
-    console.log("E-Stopped")
-  } else if (stationStatus.AStop && data.MatchState==0) {
-    $("#match").addClass("blink-orange"); // A-stop: blinking orange
-    console.log("A-Stopped")
-  }
 };
 
 // Handles a websocket message to update the match time countdown.

--- a/templates/alliance_station_display.html
+++ b/templates/alliance_station_display.html
@@ -44,7 +44,8 @@ Display shown on the screens above each driver station.
     <script src="/static/js/lib/jquery.websocket-0.0.1.js"></script>
     <script src="/static/js/cheesy-websocket.js"></script>
     <script src="/static/js/match_timing.js"></script>
-    <script src="/static/js/alliance_station_display.js"></script>
+    {{if .EventSettings.FlashDSEnabled}}<script src="/static/js/alliance_station_display.js"></script>{{end}}
+    {{if not .EventSettings.FlashDSEnabled}}<script src="/static/js/alliance_station_display_noflash.js"></script>{{end}}
     {{range $sound := .MatchSounds}}
     <audio id="sound-{{$sound.Name}}" src="/static/audio/{{$sound.Name}}.{{$sound.FileExtension}}" preload="auto">
     </audio>

--- a/templates/setup_settings.html
+++ b/templates/setup_settings.html
@@ -549,6 +549,18 @@ UI for configuring event settings.
                 </div>
               </div>
             </fieldset>
+            <fieldset class="mb-4">
+              <legend>Alliance Station Enhancements</legend>
+              <p>Enable this setting to allow the driver station displays to flash orange to indiciate an e-stop, or solid orange
+                to indiciate an a-stop. When enabled, the driver station will only flash outside of the match. <b>Display reload required for changes to take effect.</b>
+              </p>
+              <div class="row mb-3">
+                <label class="col-lg-6 control-label">Enable DS E/A Stop Alerting</label>
+                <div class="col-lg-1 checkbox">
+                  <input type="checkbox" name="flashDSEnabled" {{if .FlashDSEnabled}}checked{{end}}>
+                </div>
+              </div>
+            </fieldset>
           </div>
           <div class="row justify-content-center">
             <div class="col-lg-3 align-items-center">

--- a/web/setup_settings.go
+++ b/web/setup_settings.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"time"
-	"log"
 
 	"github.com/Team254/cheesy-arena/model"
 )
@@ -59,8 +59,8 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("setup_settings.go eventSettings.ElimType: double")
 		numAlliances, _ = strconv.Atoi(r.PostFormValue("numPlayoffAlliances"))
 		log.Printf("setup_settings.go numAlliances: %v", numAlliances)
-		
-		if  numAlliances < 3 || numAlliances > 8 {
+
+		if numAlliances < 3 || numAlliances > 8 {
 			web.renderSettings(w, r, "Number of alliances For Double Must be between 3 and 8.")
 			return
 		}
@@ -130,6 +130,7 @@ func (web *Web) settingsPostHandler(w http.ResponseWriter, r *http.Request) {
 	eventSettings.RedAllianceStationEstopAddress = r.PostFormValue("RedAllianceStationEstopAddress")
 	eventSettings.BlueAllianceStationEstopAddress = r.PostFormValue("BlueAllianceStationEstopAddress")
 	eventSettings.LogoSuffix = r.PostFormValue("logosuffix")
+	eventSettings.FlashDSEnabled = r.PostFormValue("flashDSEnabled") == "on"
 
 	err := web.arena.Database.UpdateEventSettings(eventSettings)
 	if err != nil {


### PR DESCRIPTION
resolve issue with driver station display changing to flash color or solid when e-stop or a-stop is tripped during a match.

added functionality to disable the flash all together in the automations.

<img width="1059" height="312" alt="image" src="https://github.com/user-attachments/assets/6f026c65-dfc2-4b05-a981-92676ec4c66e" />
